### PR TITLE
Add basic generation testing code 

### DIFF
--- a/tessellation/draw.py
+++ b/tessellation/draw.py
@@ -33,8 +33,9 @@ class Drawer:
         side_len_full_image = side_len * n_shapes
         tessellation = np.zeros((side_len_full_image, side_len_full_image), dtype=int)
 
-        color = 0
+        row_starting_color = 1
         for i in range(n_shapes):
+            cell_color = row_starting_color
             for j in range(n_shapes):
                 y_start = i * side_len
                 y_end = y_start + side_len
@@ -42,13 +43,15 @@ class Drawer:
                 x_start = j * side_len
                 x_end = x_start + side_len
 
-                if color == 0:
+                if cell_color == 0:
                     color_mask = np.logical_not(mask)
-                    color = 1
+                    cell_color = 1
                 else:
                     color_mask = mask
-                    color = 0
+                    cell_color = 0
 
                 tessellation[y_start:y_end, x_start:x_end] = color_mask
+
+            row_starting_color = 1 if row_starting_color == 0 else 0
 
         return tessellation

--- a/tessellation/procgen/generator.py
+++ b/tessellation/procgen/generator.py
@@ -25,16 +25,16 @@ class Generator(ABC):
         cursor = {"x": start_point[1], "y": start_point[0]}
         mask[cursor["y"], cursor["x"]] = 1
         for action in action_list:
-            if cursor["y"] >= 0:
-                mask[0 : cursor["y"], cursor["x"]] = 1
-            else:
-                mask[cursor["y"] :, cursor["x"]] = 1
-
             if action in [Action.UP_RIGHT, Action.UP]:
                 cursor["y"] -= 1
             if action in [Action.DOWN_RIGHT, Action.DOWN]:
                 cursor["y"] += 1
             if action in [Action.UP_RIGHT, Action.DOWN_RIGHT, Action.RIGHT]:
                 cursor["x"] += 1
+
+            if cursor["y"] >= 0:
+                mask[0 : cursor["y"] + 1, cursor["x"]] = 1
+            else:
+                mask[cursor["y"] :, cursor["x"]] = 1
 
         return mask

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+from tessellation.procgen import GenerationResult, TessellationType
+
+
+@pytest.fixture
+def square_tessellation_mask():
+    return np.array([[1, 0], [0, 1]])
+
+
+@pytest.fixture
+def generation_result(square_tessellation_mask):
+    return GenerationResult(
+        mask=square_tessellation_mask,
+        tessellation_type=TessellationType.SQUARE_TRANSLATION,
+    )

--- a/tests/procgen/test_generation_result.py
+++ b/tests/procgen/test_generation_result.py
@@ -1,0 +1,45 @@
+import json
+import os
+
+import numpy as np
+import pytest
+
+from tessellation.procgen import GenerationResult
+
+
+@pytest.fixture(autouse=True)
+def saved_generation_result_path(generation_result):
+    file_path = "test.json"
+    generation_result.save_as_json(file_path)
+    yield file_path
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+
+def test_save_as_json(generation_result, saved_generation_result_path):
+    with open(saved_generation_result_path, "r") as file:
+        data = json.load(file)
+
+    expected_data = {
+        "mask": generation_result.mask.tolist(),
+        "tessellation_type": generation_result.tessellation_type.value,
+        "metadata": generation_result.metadata,
+    }
+    assert data == expected_data
+
+
+def test_to_json(generation_result):
+    expected_data = {
+        "mask": generation_result.mask.tolist(),
+        "tessellation_type": generation_result.tessellation_type.value,
+        "metadata": generation_result.metadata,
+    }
+    assert generation_result.to_json() == expected_data
+
+
+def test_read_json(generation_result, saved_generation_result_path):
+    loaded_result = GenerationResult.read_json(saved_generation_result_path)
+
+    assert np.array_equal(loaded_result.mask, generation_result.mask)
+    assert loaded_result.tessellation_type == generation_result.tessellation_type
+    assert loaded_result.metadata == generation_result.metadata

--- a/tests/procgen/test_generator.py
+++ b/tests/procgen/test_generator.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+from tessellation.procgen.generator import Generator
+from tessellation.procgen.action import Action
+
+
+class TestGenerator(Generator):
+    """A concrete implementation of Generator for testing purposes."""
+
+    pass
+
+
+@pytest.fixture
+def generator():
+    return TestGenerator()
+
+
+def test_generate_not_implemented(generator):
+    with pytest.raises(NotImplementedError):
+        generator.generate()
+
+
+def test_draw_line():
+    mask = np.zeros((5, 5), dtype=int)
+    start_point = (0, 0)
+    action_list = [
+        Action.UP,
+        Action.UP_RIGHT,
+        Action.DOWN_RIGHT,
+        Action.DOWN,
+        Action.DOWN_RIGHT,
+    ]
+
+    expected_mask = np.array(
+        [
+            [1, 0, 1, 1, 0],
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [1, 1, 1, 0, 0],
+        ]
+    )
+
+    result_mask = Generator._draw_line(mask, start_point, action_list)
+    np.testing.assert_array_equal(result_mask, expected_mask)

--- a/tests/procgen/test_rng_generator.py
+++ b/tests/procgen/test_rng_generator.py
@@ -1,0 +1,42 @@
+import pytest
+from tessellation.procgen.rng.rng_generator import RNGGenerator
+from tessellation.procgen.action import Action
+from tessellation.procgen.generation_result import GenerationResult
+from tessellation.procgen.tessellation_type import TessellationType
+
+
+@pytest.fixture
+def rng_generator():
+    return RNGGenerator(seed=42)
+
+
+def test_generate(rng_generator):
+    side_len = 5
+    generation_result = rng_generator.generate(side_len)
+
+    assert isinstance(generation_result, GenerationResult)
+    assert generation_result.mask.shape == (side_len, side_len)
+    assert generation_result.tessellation_type == TessellationType.SQUARE_TRANSLATION
+
+
+def test_generate_side(rng_generator):
+    side_len = 5
+    action_probs = [0.2, 0.2, 0.2, 0.2, 0.2]
+    mask, action_list = rng_generator._generate_side(side_len, action_probs)
+
+    assert mask.shape == (side_len, side_len)
+    assert all(isinstance(action, Action) for action in action_list)
+
+
+def test_get_rand_action(rng_generator):
+    actions_list = [
+        Action.UP,
+        Action.UP_RIGHT,
+        Action.RIGHT,
+        Action.DOWN,
+        Action.DOWN_RIGHT,
+    ]
+    action_probs = [0.2, 0.2, 0.2, 0.2, 0.2]
+    action = rng_generator._get_rand_action(actions_list, action_probs)
+
+    assert action in actions_list

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+from tessellation.draw import Drawer
+
+
+@pytest.fixture
+def drawer():
+    return Drawer()
+
+
+def test_tessellate(drawer, generation_result):
+    n_shapes = 2
+    actual_tessellation = drawer.tessellate(generation_result, n_shapes)
+
+    expected_tessellation = np.array(
+        [
+            [1, 0, 0, 1],
+            [0, 1, 1, 0],
+            [0, 1, 1, 0],
+            [1, 0, 0, 1],
+        ]
+    )
+    np.testing.assert_array_equal(actual_tessellation, expected_tessellation)


### PR DESCRIPTION
Closes: https://github.com/adachille/tessellation/issues/14

Add basic generation testing code, which lead to a few bug fixes.

- Bug fixes
    - Fix a bug where the drawer would not tessellate properly if the number of shapes was even.
    - Fix an off-by-1 indexing bug in `generator._draw_line`
    - Fix a bug in `generator._draw_line` where the last point would not be drawn
- Add tests
    - Add tests for `Drawer` class
    - Add tests for `Generator` class
    - Add tests for `GenerationResult` class
    - Add tests for `RNGGenerator` class